### PR TITLE
Reduce Required Permissions for Content Script

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -41,19 +41,6 @@
     "page": "pages/options.html",
     "open_in_tab": false
   },
-  "content_scripts": [
-    {
-      "all_frames": true,
-      "js": [
-        "scripts/content-script.js"
-      ],
-      "match_about_blank": true,
-      "matches": [
-        "<all_urls>"
-      ],
-      "run_at": "document_idle"
-    }
-  ],
   "permissions": [
     "activeTab",
     "contextMenus",

--- a/app/scripts/content-script.js
+++ b/app/scripts/content-script.js
@@ -4,14 +4,6 @@ import {
 } from "utils/grids";
 import { GetSetting } from "utils/settings";
 
-browser.runtime.onMessage.addListener((message, sender) => {
-  // console.log("Content Script Runtime Message", sender, message);
-  switch (message.action) {
-    case "fill-grid":
-      return AutoFillGrid(message.grid);
-  }
-});
-
 const ShowBasicNotification = (title, message) =>
   browser.runtime.sendMessage({
     action: "show-basic-notification",
@@ -120,3 +112,11 @@ const AutoFillGrid = async (grid) => {
     form.submit();
   }
 };
+
+browser.runtime.onMessage.addListener((message, _sender) => {
+  // console.log("Content Script Runtime Message", sender, message);
+  switch (message.action) {
+    case "fill-grid":
+      return AutoFillGrid(message.grid);
+  }
+});

--- a/app/scripts/utils/grids/index.js
+++ b/app/scripts/utils/grids/index.js
@@ -42,15 +42,16 @@ export const GetGridFromStorageByID = async (id) => {
  */
 export const FillGridInActiveTab = (grid) =>
   browser.tabs
-    .query({
-      active: true,
-      currentWindow: true,
-    })
+    .executeScript({ file: "/scripts/content-script.js" })
+    .then(() => browser.tabs.query({ active: true, currentWindow: true }))
     .then((tabs) =>
       browser.tabs.sendMessage(tabs[0].id, {
         action: "fill-grid",
         grid,
       })
+    )
+    .catch((error) =>
+      console.error("Failed to fill grid in active tab", error)
     );
 
 /**


### PR DESCRIPTION
This PR includes an alternate implementation of the content script (primarily how/when it is injected) to avoid needing the `<all_urls>` permission.